### PR TITLE
test for ENV variables before require added_methods

### DIFF
--- a/lib/brice/rc/010_added_methods.rb
+++ b/lib/brice/rc/010_added_methods.rb
@@ -4,14 +4,16 @@
 # +WATCH_FOR_ADDED_METHODS+::    Regular expression or +true+
 # +WATCH_FOR_ADDED_METHODS_IN+:: Space- or comma-delimited list of class names
 
-brice 'added_methods' do |config|
+if ENV['WATCH_FOR_ADDED_METHODS'] || ENV['WATCH_FOR_ADDED_METHODS_IN']
+  brice 'added_methods' do |config|
 
-  pattern = ENV['WATCH_FOR_ADDED_METHODS']
-  list    = ENV['WATCH_FOR_ADDED_METHODS_IN']
+    pattern = ENV['WATCH_FOR_ADDED_METHODS']
+    list    = ENV['WATCH_FOR_ADDED_METHODS_IN']
 
-  AddedMethods.init(
-    (pattern != 'true' || list) && Regexp.new(pattern || ''),
-    (list || '').split(/\s|,/).reject { |name| name.empty? }
-  ) if pattern || list
+    AddedMethods.init(
+      (pattern != 'true' || list) && Regexp.new(pattern || ''),
+      (list || '').split(/\s|,/).reject { |name| name.empty? }
+    ) if pattern || list
 
+  end
 end


### PR DESCRIPTION
Using Brice without AddedMethods results in this error while loading the rails console. 

> LoadError: cannot load such file -- added_methods [/Users/ben/.rvm/gems/ruby-1.9.3-p125/gems/activesupport-3.2.12/lib/active_support/dependencies.rb:245:in `load']

That was caused by `Brice::DSL.brice(package)` calling `Brice::DSL.brice_require` independent of running the configuration block in `lib/brice/rc/010_added_methods.rb`. 

This pullrequest fixes this by scoping the `brice 'added_methods' do |config| …` in `lib/brice/rc/010_added_methods.rb` with a test for required environment variables. 
